### PR TITLE
Chore: (Docs) Updates link for support table

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Storybook GraphQL Addon can be used to display the GraphiQL IDE with example queries in [Storybook](https://storybook.js.org).
 
-[Framework Support](https://github.com/storybookjs/storybook/blob/master/ADDONS_SUPPORT.md)
+[Framework Support](https://storybook.js.org/docs/react/api/frameworks-feature-support)
 
 ![Screenshot](https://raw.githubusercontent.com/storybookjs/storybook/HEAD/addons/graphql/docs/screenshot.png)
 


### PR DESCRIPTION
With this small pull request, the Framework support link is updated to its proper location as the Addon Support table is no longer a source of truth.

Addresses #17150

